### PR TITLE
fix agrs 1char no panic (fix issue #21)

### DIFF
--- a/flaeg.go
+++ b/flaeg.go
@@ -755,6 +755,9 @@ func isExported(fieldName string) bool {
 }
 
 func argToLower(inArg string) string {
+	if len(inArg) < 2 {
+		return strings.ToLower(inArg)
+	}
 	var outArg string
 	dashIndex := strings.Index(inArg, "--")
 	if dashIndex == -1 {


### PR DESCRIPTION
fix panic slice bounds out of range in func `argToLower` 