### PR TITLE
Fix problem with repeat struct ptr with one on root

### DIFF
--- a/flaeg.go
+++ b/flaeg.go
@@ -343,7 +343,7 @@ func fillStructRecursive(objValue reflect.Value, defaultPointerValmap map[string
 		contains := false
 		for flag := range valmap {
 			// TODO replace by regexp
-			if strings.Contains(flag, name+".") {
+			if strings.HasPrefix(flag, name+".") {
 				contains = true
 				break
 			}


### PR DESCRIPTION
### What does this PR do?
Fix a bug when there is struct pointer repeated with one on root

### Motivation
Fix a bug in traefik where `--metrics` is filled when we fill `--web.metrics.prometheus`

### More
- [x] Added/updated tests
