### PR TITLE
Move parser into its own package

### DIFF
--- a/flaeg.go
+++ b/flaeg.go
@@ -14,8 +14,7 @@ import (
 	"text/template"
 	"time"
 
-	parse "github.com/containous/flaeg/parse"
-
+	"github.com/containous/flaeg/parse"
 	flag "github.com/ogier/pflag"
 )
 

--- a/flaeg.go
+++ b/flaeg.go
@@ -14,6 +14,8 @@ import (
 	"text/template"
 	"time"
 
+	parse "github.com/containous/flaeg/parse"
+
 	flag "github.com/ogier/pflag"
 )
 
@@ -108,34 +110,34 @@ func GetFlags(config interface{}) ([]string, error) {
 
 //loadParsers loads default parsers and custom parsers given as parameter. Return a map [reflect.Type]parsers
 // bool, int, int64, uint, uint64, float64,
-func loadParsers(customParsers map[reflect.Type]Parser) (map[reflect.Type]Parser, error) {
-	parsers := map[reflect.Type]Parser{}
+func loadParsers(customParsers map[reflect.Type]parse.Parser) (map[reflect.Type]parse.Parser, error) {
+	parsers := map[reflect.Type]parse.Parser{}
 
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
 
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
 
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
 
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
 
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
 
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
 
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
 
-	var timeParser timeValue
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
 	for rType, parser := range customParsers {
@@ -146,15 +148,15 @@ func loadParsers(customParsers map[reflect.Type]Parser) (map[reflect.Type]Parser
 
 //ParseArgs : parses args return valmap map[flag]Getter, using parsers map[type]Getter
 //args must be formated as like as flag documentation. See https://golang.org/pkg/flag
-func parseArgs(args []string, flagmap map[string]reflect.StructField, parsers map[reflect.Type]Parser) (map[string]Parser, error) {
+func parseArgs(args []string, flagmap map[string]reflect.StructField, parsers map[reflect.Type]parse.Parser) (map[string]parse.Parser, error) {
 	//Return var
-	valmap := make(map[string]Parser)
+	valmap := make(map[string]parse.Parser)
 	//Visitor in flag.Parse
 	flagList := []*flag.Flag{}
 	visitor := func(fl *flag.Flag) {
 		flagList = append(flagList, fl)
 	}
-	newParsers := map[string]Parser{}
+	newParsers := map[string]parse.Parser{}
 	flagSet := flag.NewFlagSet("flaeg.Load", flag.ContinueOnError)
 	//Disable output
 	flagSet.SetOutput(ioutil.Discard)
@@ -165,7 +167,7 @@ func parseArgs(args []string, flagmap map[string]reflect.StructField, parsers ma
 		if parser, ok := parsers[structField.Type]; ok {
 			newparserValue := reflect.New(reflect.TypeOf(parser).Elem())
 			newparserValue.Elem().Set(reflect.ValueOf(parser).Elem())
-			newparser := newparserValue.Interface().(Parser)
+			newparser := newparserValue.Interface().(parse.Parser)
 			if short := structField.Tag.Get("short"); len(short) == 1 {
 				// fmt.Printf("short : %s long : %s\n", short, flag)
 				flagSet.VarP(newparser, flag, short, structField.Tag.Get("description"))
@@ -296,7 +298,7 @@ func setPointersNil(objValue reflect.Value) (reflect.Value, error) {
 }
 
 //FillStructRecursive initialize a value of any taged Struct given by reference
-func fillStructRecursive(objValue reflect.Value, defaultPointerValmap map[string]reflect.Value, valmap map[string]Parser, key string) error {
+func fillStructRecursive(objValue reflect.Value, defaultPointerValmap map[string]reflect.Value, valmap map[string]parse.Parser, key string) error {
 	name := key
 	switch objValue.Kind() {
 	case reflect.Struct:
@@ -379,7 +381,7 @@ func fillStructRecursive(objValue reflect.Value, defaultPointerValmap map[string
 }
 
 // SetFields sets value to fieldValue using tag as key in valmap
-func setFields(fieldValue reflect.Value, val Parser) error {
+func setFields(fieldValue reflect.Value, val parse.Parser) error {
 	if fieldValue.CanSet() {
 		fieldValue.Set(reflect.ValueOf(val).Elem().Convert(fieldValue.Type()))
 	} else {
@@ -389,12 +391,12 @@ func setFields(fieldValue reflect.Value, val Parser) error {
 }
 
 //PrintHelp generates and prints command line help
-func PrintHelp(flagmap map[string]reflect.StructField, defaultValmap map[string]reflect.Value, parsers map[reflect.Type]Parser) error {
+func PrintHelp(flagmap map[string]reflect.StructField, defaultValmap map[string]reflect.Value, parsers map[reflect.Type]parse.Parser) error {
 	return PrintHelpWithCommand(flagmap, defaultValmap, parsers, nil, nil)
 }
 
 //PrintError takes a not nil error and prints command line help
-func PrintError(err error, flagmap map[string]reflect.StructField, defaultValmap map[string]reflect.Value, parsers map[reflect.Type]Parser) error {
+func PrintError(err error, flagmap map[string]reflect.StructField, defaultValmap map[string]reflect.Value, parsers map[reflect.Type]parse.Parser) error {
 	if err != flag.ErrHelp {
 		fmt.Printf("Error : %s\n", err)
 	}
@@ -406,7 +408,7 @@ func PrintError(err error, flagmap map[string]reflect.StructField, defaultValmap
 
 //LoadWithParsers initializes config : struct fields given by reference, with args : arguments.
 //Some custom parsers may be given.
-func LoadWithParsers(config interface{}, defaultValue interface{}, args []string, customParsers map[reflect.Type]Parser) error {
+func LoadWithParsers(config interface{}, defaultValue interface{}, args []string, customParsers map[reflect.Type]parse.Parser) error {
 	cmd := &Command{
 		Config:                config,
 		DefaultPointersConfig: defaultValue,
@@ -437,7 +439,7 @@ type Command struct {
 
 //LoadWithCommand initializes config : struct fields given by reference, with args : arguments.
 //Some custom parsers and some subCommand may be given.
-func LoadWithCommand(cmd *Command, cmdArgs []string, customParsers map[reflect.Type]Parser, subCommand []*Command) error {
+func LoadWithCommand(cmd *Command, cmdArgs []string, customParsers map[reflect.Type]parse.Parser, subCommand []*Command) error {
 
 	parsers, err := loadParsers(customParsers)
 	if err != nil {
@@ -470,7 +472,7 @@ func LoadWithCommand(cmd *Command, cmdArgs []string, customParsers map[reflect.T
 }
 
 //PrintHelpWithCommand generates and prints command line help for a Command
-func PrintHelpWithCommand(flagmap map[string]reflect.StructField, defaultValmap map[string]reflect.Value, parsers map[reflect.Type]Parser, cmd *Command, subCmd []*Command) error {
+func PrintHelpWithCommand(flagmap map[string]reflect.StructField, defaultValmap map[string]reflect.Value, parsers map[reflect.Type]parse.Parser, cmd *Command, subCmd []*Command) error {
 	// Define a templates
 	// Using POSXE STD : http://pubs.opengroup.org/onlinepubs/9699919799/
 	const helper = `{{if .ProgDescription}}{{.ProgDescription}}
@@ -517,7 +519,7 @@ Flags:
 	return printFlagsDescriptionsDefaultValues(flagmap, defaultValmap, parsers, os.Stdout)
 }
 
-func printFlagsDescriptionsDefaultValues(flagmap map[string]reflect.StructField, defaultValmap map[string]reflect.Value, parsers map[reflect.Type]Parser, output io.Writer) error {
+func printFlagsDescriptionsDefaultValues(flagmap map[string]reflect.StructField, defaultValmap map[string]reflect.Value, parsers map[reflect.Type]parse.Parser, output io.Writer) error {
 	// Sort alphabetically & Delete unparsable flags in a slice
 	flags := []string{}
 	for flag, field := range flagmap {
@@ -603,7 +605,7 @@ func displayTab(output io.Writer, columns ...[]string) error {
 }
 
 //PrintErrorWithCommand takes a not nil error and prints command line help
-func PrintErrorWithCommand(err error, flagmap map[string]reflect.StructField, defaultValmap map[string]reflect.Value, parsers map[reflect.Type]Parser, cmd *Command, subCmd []*Command) error {
+func PrintErrorWithCommand(err error, flagmap map[string]reflect.StructField, defaultValmap map[string]reflect.Value, parsers map[reflect.Type]parse.Parser, cmd *Command, subCmd []*Command) error {
 	if err != flag.ErrHelp {
 		fmt.Printf("Error here : %s\n", err)
 	}
@@ -619,7 +621,7 @@ type Flaeg struct {
 	commands      []*Command ///rootCommand is th fist one in this slice
 	args          []string
 	commmandArgs  []string
-	customParsers map[reflect.Type]Parser
+	customParsers map[reflect.Type]parse.Parser
 }
 
 //New creats and initialize a pointer on Flaeg
@@ -627,7 +629,7 @@ func New(rootCommand *Command, args []string) *Flaeg {
 	var f Flaeg
 	f.commands = []*Command{rootCommand}
 	f.args = args
-	f.customParsers = map[reflect.Type]Parser{}
+	f.customParsers = map[reflect.Type]parse.Parser{}
 	return &f
 }
 
@@ -637,7 +639,7 @@ func (f *Flaeg) AddCommand(command *Command) {
 }
 
 //AddParser adds custom parser for a type to the map of custom parsers
-func (f *Flaeg) AddParser(typ reflect.Type, parser Parser) {
+func (f *Flaeg) AddParser(typ reflect.Type, parser parse.Parser) {
 	f.customParsers[typ] = parser
 }
 

--- a/flaeg.go
+++ b/flaeg.go
@@ -135,7 +135,7 @@ func loadParsers(customParsers map[reflect.Type]parse.Parser) (map[reflect.Type]
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser

--- a/flaeg_test.go
+++ b/flaeg_test.go
@@ -30,11 +30,11 @@ type RepeatedStructContainer struct {
 //Configuration is a struct which contains all differents type to field
 //using parsers on string, time.Duration, pointer, bool, int, int64, time.Time, float64
 type Configuration struct {
-	Name     string        //no description struct tag, it will not be flaged
-	LogLevel string        `short:"l" description:"Log level"`      //string type field, short flag "-l"
-	Timeout  time.Duration `description:"Timeout duration"`         // Duration type field
-	Db       *DatabaseInfo `description:"Enable database"`          //pointer type field (on DatabaseInfo)
-	Owner    *OwnerInfo    `description:"Enable Owner description"` //another pointer type field (on OwnerInfo)
+	Name     string         //no description struct tag, it will not be flaged
+	LogLevel string         `short:"l" description:"Log level"`      //string type field, short flag "-l"
+	Timeout  parse.Duration `description:"Timeout duration"`         // Duration type field
+	Db       *DatabaseInfo  `description:"Enable database"`          //pointer type field (on DatabaseInfo)
+	Owner    *OwnerInfo     `description:"Enable Owner description"` //another pointer type field (on OwnerInfo)
 }
 
 type ServerInfo struct {
@@ -91,7 +91,7 @@ func newConfiguration() *Configuration {
 	return &Configuration{
 		Name:     "initName",
 		LogLevel: "DEBUG",
-		Timeout:  time.Duration(time.Second),
+		Timeout:  parse.Duration(time.Second),
 		Owner:    &own,
 	}
 }
@@ -105,7 +105,7 @@ func TestGetTypesRecursive(t *testing.T) {
 	// Check only type
 	checkType := map[string]reflect.Type{
 		"loglevel":           reflect.TypeOf(""),
-		"timeout":            reflect.TypeOf(time.Duration(time.Second)),
+		"timeout":            reflect.TypeOf(parse.Duration(time.Second)),
 		"db":                 reflect.TypeOf(true),
 		"db.watch":           reflect.TypeOf(true),
 		"db.ip":              reflect.TypeOf(""),
@@ -235,7 +235,7 @@ func TestLoadParsers(t *testing.T) {
 	var float64Parser parse.Float64Value
 	check[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	check[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	check[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	check[reflect.TypeOf(time.Now())] = &timeParser
 	if len(check) != len(parsers) {
@@ -275,7 +275,7 @@ func TestParseArgsTrivialFlags(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
@@ -293,7 +293,7 @@ func TestParseArgsTrivialFlags(t *testing.T) {
 	check := map[string]parse.Parser{}
 	stringParser.SetValue("OFF")
 	check["loglevel"] = &stringParser
-	durationParser.SetValue(time.Duration(9 * time.Millisecond))
+	durationParser.SetValue(parse.Duration(9 * time.Millisecond))
 	check["timeout"] = &durationParser
 	if len(check) != len(valmap) {
 		t.Fatalf("Error, expected %d elements in valmap got %d", len(check), len(valmap))
@@ -332,7 +332,7 @@ func TestParseArgsShortFlags(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
@@ -386,7 +386,7 @@ func TestParseArgsPointerFlag(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
@@ -443,7 +443,7 @@ func TestParseArgsUnderPointerFlag(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
@@ -502,7 +502,7 @@ func TestParseArgsPointerFlagUnderPointerFlag(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
@@ -561,7 +561,7 @@ func TestParseArgsCustomFlag(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
@@ -619,7 +619,7 @@ func TestParseArgsAll(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
@@ -649,7 +649,7 @@ func TestParseArgsAll(t *testing.T) {
 	check := map[string]parse.Parser{}
 	stringParser.SetValue("INFO")
 	check["loglevel"] = &stringParser
-	durationParser.SetValue(time.Duration(time.Second))
+	durationParser.SetValue(parse.Duration(time.Second))
 	check["timeout"] = &durationParser
 	boolParser.SetValue(true)
 	check["db"] = &boolParser
@@ -709,7 +709,7 @@ func TestParseArgsErrorNoParser(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
@@ -745,7 +745,7 @@ func TestGetDefaultValueInitConfigAllDefault(t *testing.T) {
 	checkDob, _ := time.Parse(time.RFC3339, "1993-09-12T07:32:00Z")
 	checkValue := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf("DEBUG"),
-		"timeout":            reflect.ValueOf(time.Duration(time.Second)),
+		"timeout":            reflect.ValueOf(parse.Duration(time.Second)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{ServerInfo: ServerInfo{Watch: true, IP: "192.168.1.2", Load: 32, Load64: 64}, ConnectionMax: 3200000000, ConnectionMax64: 6400000000000000000}),
 		"db.watch":           reflect.ValueOf(true),
 		"db.ip":              reflect.ValueOf("192.168.1.2"),
@@ -785,7 +785,7 @@ func TestGetDefaultValueNoConfigNoDefault(t *testing.T) {
 	}
 	checkValue := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf(""),
-		"timeout":            reflect.ValueOf(time.Duration(0)),
+		"timeout":            reflect.ValueOf(parse.Duration(0)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{}),
 		"db.watch":           reflect.ValueOf(false),
 		"db.ip":              reflect.ValueOf(""),
@@ -815,7 +815,7 @@ func TestGetDefaultValueInitConfigNoDefault(t *testing.T) {
 	config := &Configuration{
 		Name: "defaultName", //useless field not flaged
 		// LogLevel is not initialized, default value will be go default value : ""
-		Timeout: time.Duration(time.Millisecond),
+		Timeout: parse.Duration(time.Millisecond),
 	}
 	defPointerConfig := &Configuration{
 		Db: nil, //If pointer field is nil, default value will be go default value
@@ -827,7 +827,7 @@ func TestGetDefaultValueInitConfigNoDefault(t *testing.T) {
 	}
 	checkValue := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf(""),
-		"timeout":            reflect.ValueOf(time.Duration(time.Millisecond)),
+		"timeout":            reflect.ValueOf(parse.Duration(time.Millisecond)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{}),
 		"db.watch":           reflect.ValueOf(false),
 		"db.ip":              reflect.ValueOf(""),
@@ -865,7 +865,7 @@ func TestGetDefaultNoConfigAllDefault(t *testing.T) {
 	checkDob, _ := time.Parse(time.RFC3339, "1979-05-27T07:32:00Z")
 	checkValue := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf(""),
-		"timeout":            reflect.ValueOf(time.Duration(0)),
+		"timeout":            reflect.ValueOf(parse.Duration(0)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{ServerInfo: ServerInfo{Watch: true, IP: "192.168.1.2", Load: 32, Load64: 64}, ConnectionMax: 3200000000, ConnectionMax64: 6400000000000000000}),
 		"db.watch":           reflect.ValueOf(true),
 		"db.ip":              reflect.ValueOf("192.168.1.2"),
@@ -911,7 +911,7 @@ func TestFillStructRecursiveNoConfigNoDefaultTrivialValmap(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
@@ -919,7 +919,7 @@ func TestFillStructRecursiveNoConfigNoDefaultTrivialValmap(t *testing.T) {
 	valmap := map[string]parse.Parser{}
 	stringParser.SetValue("INFO")
 	valmap["loglevel"] = &stringParser
-	durationParser.SetValue(time.Duration(time.Second))
+	durationParser.SetValue(parse.Duration(time.Second))
 	valmap["timeout"] = &durationParser
 
 	//init defaultValmap NoConfigNoDefault
@@ -949,7 +949,7 @@ func TestFillStructRecursiveNoConfigNoDefaultTrivialValmap(t *testing.T) {
 	// fmt.Printf("Got : %+v\n", config)
 	check := &Configuration{}
 	check.LogLevel = "INFO"
-	check.Timeout = time.Duration(time.Second)
+	check.Timeout = parse.Duration(time.Second)
 	if !reflect.DeepEqual(config, check) {
 		t.Fatalf("Error :\nexpected \t%+v \ngot \t\t%+v\n", check, config)
 	}
@@ -978,7 +978,7 @@ func TestFillStructRecursiveNoConfigNoDefaultAllValmap(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
@@ -986,7 +986,7 @@ func TestFillStructRecursiveNoConfigNoDefaultAllValmap(t *testing.T) {
 	valmap := map[string]parse.Parser{}
 	stringParser.SetValue("INFO")
 	valmap["loglevel"] = &stringParser
-	durationParser.SetValue(time.Duration(time.Second))
+	durationParser.SetValue(parse.Duration(time.Second))
 	valmap["timeout"] = &durationParser
 	boolParser.SetValue(true)
 	valmap["db"] = &boolParser
@@ -1015,7 +1015,7 @@ func TestFillStructRecursiveNoConfigNoDefaultAllValmap(t *testing.T) {
 	//init defaultValmap NoConfigNoDefault
 	defaultValmap := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf(""),
-		"timeout":            reflect.ValueOf(time.Duration(0)),
+		"timeout":            reflect.ValueOf(parse.Duration(0)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{}),
 		"db.watch":           reflect.ValueOf(false),
 		"db.ip":              reflect.ValueOf(""),
@@ -1040,7 +1040,7 @@ func TestFillStructRecursiveNoConfigNoDefaultAllValmap(t *testing.T) {
 	checkDob, _ := time.Parse(time.RFC3339, "2016-04-20T17:39:00Z")
 	check := &Configuration{
 		LogLevel: "INFO",
-		Timeout:  time.Duration(time.Second),
+		Timeout:  parse.Duration(time.Second),
 		Db: &DatabaseInfo{
 			ServerInfo: ServerInfo{
 				Watch:  true,
@@ -1087,7 +1087,7 @@ func TestFillStructRecursiveNoConfigAllDefaultNoValmap(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
@@ -1099,7 +1099,7 @@ func TestFillStructRecursiveNoConfigAllDefaultNoValmap(t *testing.T) {
 	defaultDob, _ := time.Parse(time.RFC3339, "1979-05-27T07:32:00Z")
 	defaultValmap := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf(""),
-		"timeout":            reflect.ValueOf(time.Duration(0)),
+		"timeout":            reflect.ValueOf(parse.Duration(0)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{ServerInfo: ServerInfo{Watch: true, IP: "192.168.1.2", Load: 32, Load64: 64}, ConnectionMax: 3200000000, ConnectionMax64: 6400000000000000000}),
 		"db.watch":           reflect.ValueOf(true),
 		"db.ip":              reflect.ValueOf("192.168.1.2"),
@@ -1149,7 +1149,7 @@ func TestFillStructRecursiveInitConfigAllDefaultNoValmap(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
@@ -1217,7 +1217,7 @@ func TestFillStructRecursiveInitConfigAllDefaultPointerValmap(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
@@ -1304,7 +1304,7 @@ func TestFillStructRecursiveInitConfigAllDefaultPointerUnderPointerValmap(t *tes
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
@@ -1344,7 +1344,7 @@ func TestFillStructRecursiveInitConfigAllDefaultPointerUnderPointerValmap(t *tes
 	check := &Configuration{
 		Name:     "initName",
 		LogLevel: "DEBUG",
-		Timeout:  time.Duration(time.Second),
+		Timeout:  parse.Duration(time.Second),
 		Owner: &OwnerInfo{
 			Name:        &checkDefaultStr,
 			DateOfBirth: checkDob,
@@ -1382,13 +1382,13 @@ func TestFillStructRecursiveNoConfigAllDefaultSomeValmap(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
 	//init valmap
 	valmap := map[string]parse.Parser{}
-	durationParser.SetValue(5 * time.Duration(time.Second))
+	durationParser.SetValue(5 * parse.Duration(time.Second))
 	valmap["timeout"] = &durationParser
 	boolParser.SetValue(true)
 	valmap["db"] = &boolParser
@@ -1402,7 +1402,7 @@ func TestFillStructRecursiveNoConfigAllDefaultSomeValmap(t *testing.T) {
 	defaultDob, _ := time.Parse(time.RFC3339, "1979-05-27T07:32:00Z")
 	defaultValmap := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf(""),
-		"timeout":            reflect.ValueOf(time.Duration(0)),
+		"timeout":            reflect.ValueOf(parse.Duration(0)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{ServerInfo: ServerInfo{Watch: true, IP: "192.168.1.2", Load: 32, Load64: 64}, ConnectionMax: 3200000000, ConnectionMax64: 6400000000000000000}),
 		"db.watch":           reflect.ValueOf(true),
 		"db.ip":              reflect.ValueOf("192.168.1.2"),
@@ -1424,7 +1424,7 @@ func TestFillStructRecursiveNoConfigAllDefaultSomeValmap(t *testing.T) {
 	//CHECK
 	// fmt.Printf("Got : %+v\n", config)
 	check := &Configuration{}
-	check.Timeout = 5 * time.Duration(time.Second)
+	check.Timeout = 5 * parse.Duration(time.Second)
 	check.Db = newDefaultPointersConfiguration().Db
 	check.Owner = newDefaultPointersConfiguration().Owner
 	check.Owner.DateOfBirth, _ = time.Parse(time.RFC3339, "2016-04-20T17:39:00Z")
@@ -1577,7 +1577,7 @@ func TestLoadWithParsersInitConfigNoDefaultAllFlag(t *testing.T) {
 	check := &Configuration{
 		Name:     "initName",
 		LogLevel: "INFO",
-		Timeout:  time.Duration(time.Second),
+		Timeout:  parse.Duration(time.Second),
 		Db: &DatabaseInfo{
 			ServerInfo: ServerInfo{
 				Watch:  true,
@@ -1758,7 +1758,7 @@ func TestParseArgsInvalidArgument(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
@@ -1800,7 +1800,7 @@ func TestParseArgsErrorUnknownFlag(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
@@ -1840,7 +1840,7 @@ func TestPrintErrorInvalidArgument(t *testing.T) {
 	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
 	var durationParser parse.Duration
-	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	parsers[reflect.TypeOf(parse.Duration(time.Second))] = &durationParser
 	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
@@ -1853,7 +1853,7 @@ func TestPrintErrorInvalidArgument(t *testing.T) {
 	checkDob, _ := time.Parse(time.RFC3339, "1993-09-12T07:32:00Z")
 	defaultValmap := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf("DEBUG"),
-		"timeout":            reflect.ValueOf(time.Duration(time.Second)),
+		"timeout":            reflect.ValueOf(parse.Duration(time.Second)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{ServerInfo: ServerInfo{Watch: true, IP: "192.168.1.2", Load: 32, Load64: 64}, ConnectionMax: 3200000000, ConnectionMax64: 6400000000000000000}),
 		"db.watch":           reflect.ValueOf(true),
 		"db.ip":              reflect.ValueOf("192.168.1.2"),
@@ -2525,7 +2525,7 @@ func TestSetPointersNilFullConfig(t *testing.T) {
 	config := &Configuration{
 		Name:     "Toto",
 		LogLevel: "Tata",
-		Timeout:  time.Duration(time.Nanosecond),
+		Timeout:  parse.Duration(time.Nanosecond),
 		Db: &DatabaseInfo{
 			ServerInfo: ServerInfo{
 				Watch:  true,
@@ -2550,7 +2550,7 @@ func TestSetPointersNilFullConfig(t *testing.T) {
 	check := &Configuration{
 		Name:     "Toto",
 		LogLevel: "Tata",
-		Timeout:  time.Duration(time.Nanosecond),
+		Timeout:  parse.Duration(time.Nanosecond),
 	}
 	if !reflect.DeepEqual(nilPointersConfig.Interface(), check) {
 		t.Errorf("\nexpected \t%+v \ngot \t\t%+v\n", check, nilPointersConfig.Interface())
@@ -2558,7 +2558,7 @@ func TestSetPointersNilFullConfig(t *testing.T) {
 	checkInit := &Configuration{
 		Name:     "Toto",
 		LogLevel: "Tata",
-		Timeout:  time.Duration(time.Nanosecond),
+		Timeout:  parse.Duration(time.Nanosecond),
 		Db: &DatabaseInfo{
 			ServerInfo: ServerInfo{
 				Watch:  true,

--- a/flaeg_test.go
+++ b/flaeg_test.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 	"testing"
 	"time"
-)
 
+	parse "github.com/containous/flaeg/parse"
+)
 
 //ConfigurationWithRepeatedStruct is struct which contains repeated struct
 type ConfigurationWithRepeatedStruct struct {
-	Repeated *RepeatedStruct `description:"Repeated struct"`
+	Repeated  *RepeatedStruct          `description:"Repeated struct"`
 	Container *RepeatedStructContainer `description:"Container"`
 }
 
@@ -31,7 +32,7 @@ type RepeatedStructContainer struct {
 type Configuration struct {
 	Name     string        //no description struct tag, it will not be flaged
 	LogLevel string        `short:"l" description:"Log level"`      //string type field, short flag "-l"
-	Timeout  Duration      `description:"Timeout duration"`         // Duration type field
+	Timeout  time.Duration `description:"Timeout duration"`         // Duration type field
 	Db       *DatabaseInfo `description:"Enable database"`          //pointer type field (on DatabaseInfo)
 	Owner    *OwnerInfo    `description:"Enable Owner description"` //another pointer type field (on OwnerInfo)
 }
@@ -90,7 +91,7 @@ func newConfiguration() *Configuration {
 	return &Configuration{
 		Name:     "initName",
 		LogLevel: "DEBUG",
-		Timeout:  Duration(time.Second),
+		Timeout:  time.Duration(time.Second),
 		Owner:    &own,
 	}
 }
@@ -104,7 +105,7 @@ func TestGetTypesRecursive(t *testing.T) {
 	// Check only type
 	checkType := map[string]reflect.Type{
 		"loglevel":           reflect.TypeOf(""),
-		"timeout":            reflect.TypeOf(Duration(time.Second)),
+		"timeout":            reflect.TypeOf(time.Duration(time.Second)),
 		"db":                 reflect.TypeOf(true),
 		"db.watch":           reflect.TypeOf(true),
 		"db.ip":              reflect.TypeOf(""),
@@ -206,7 +207,7 @@ func (c *sliceServerValue) SetValue(val interface{}) {
 
 func TestLoadParsers(t *testing.T) {
 	//inti customParsers
-	customParsers := map[reflect.Type]Parser{
+	customParsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
 	//test
@@ -216,26 +217,26 @@ func TestLoadParsers(t *testing.T) {
 	}
 
 	//Check
-	check := map[reflect.Type]Parser{
+	check := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	check[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	check[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	check[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	check[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	check[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	check[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	check[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	check[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	check[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	check[reflect.TypeOf(time.Now())] = &timeParser
 	if len(check) != len(parsers) {
 		t.Fatalf("Error, expected %d elements in parsers got %d", len(check), len(parsers))
@@ -256,26 +257,26 @@ func TestParseArgsTrivialFlags(t *testing.T) {
 		t.Errorf("Error %s", err.Error())
 	}
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
 	args := []string{
@@ -289,10 +290,10 @@ func TestParseArgsTrivialFlags(t *testing.T) {
 	}
 
 	//check
-	check := map[string]Parser{}
+	check := map[string]parse.Parser{}
 	stringParser.SetValue("OFF")
 	check["loglevel"] = &stringParser
-	durationParser.SetValue(Duration(9 * time.Millisecond))
+	durationParser.SetValue(time.Duration(9 * time.Millisecond))
 	check["timeout"] = &durationParser
 	if len(check) != len(valmap) {
 		t.Fatalf("Error, expected %d elements in valmap got %d", len(check), len(valmap))
@@ -313,26 +314,26 @@ func TestParseArgsShortFlags(t *testing.T) {
 		t.Errorf("Error %s", err.Error())
 	}
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
 	args := []string{
@@ -345,7 +346,7 @@ func TestParseArgsShortFlags(t *testing.T) {
 	}
 
 	//check
-	check := map[string]Parser{}
+	check := map[string]parse.Parser{}
 	stringParser.Set("WARN")
 	check["loglevel"] = &stringParser
 	if len(check) != len(valmap) {
@@ -367,26 +368,26 @@ func TestParseArgsPointerFlag(t *testing.T) {
 		t.Errorf("Error %s", err.Error())
 	}
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
 	args := []string{
@@ -400,10 +401,10 @@ func TestParseArgsPointerFlag(t *testing.T) {
 	}
 
 	//check
-	check := map[string]Parser{}
-	checkDb := boolValue(true)
+	check := map[string]parse.Parser{}
+	checkDb := parse.BoolValue(true)
 	check["db"] = &checkDb
-	checkOwner := boolValue(true)
+	checkOwner := parse.BoolValue(true)
 	check["owner"] = &checkOwner
 	if len(check) != len(valmap) {
 		t.Fatalf("Error, expected %d elements in valmap got %d", len(check), len(valmap))
@@ -424,26 +425,26 @@ func TestParseArgsUnderPointerFlag(t *testing.T) {
 		t.Errorf("Error %s", err.Error())
 	}
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
 	args := []string{
@@ -457,7 +458,7 @@ func TestParseArgsUnderPointerFlag(t *testing.T) {
 	}
 
 	//check
-	check := map[string]Parser{}
+	check := map[string]parse.Parser{}
 	boolParser.SetValue(true)
 	check["owner.name"] = &boolParser
 	uintParser.SetValue(uint(5000000000))
@@ -483,26 +484,26 @@ func TestParseArgsPointerFlagUnderPointerFlag(t *testing.T) {
 		t.Errorf("Error %s", err.Error())
 	}
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
 	args := []string{
@@ -517,7 +518,7 @@ func TestParseArgsPointerFlagUnderPointerFlag(t *testing.T) {
 	}
 
 	//check
-	check := map[string]Parser{}
+	check := map[string]parse.Parser{}
 	boolParser.SetValue(true)
 	check["db"] = &boolParser
 	uint64Parser.SetValue(uint64(900))
@@ -542,26 +543,26 @@ func TestParseArgsCustomFlag(t *testing.T) {
 		t.Errorf("Error %s", err.Error())
 	}
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
 	args := []string{
@@ -575,7 +576,7 @@ func TestParseArgsCustomFlag(t *testing.T) {
 	}
 
 	//check
-	check := map[string]Parser{}
+	check := map[string]parse.Parser{}
 	checkOwnerServers := sliceServerValue{
 		ServerInfo{IP: "127.0.0.1"},
 		ServerInfo{IP: "1.0.0.1"},
@@ -600,26 +601,26 @@ func TestParseArgsAll(t *testing.T) {
 		t.Errorf("Error %s", err.Error())
 	}
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
 	args := []string{
@@ -645,15 +646,15 @@ func TestParseArgsAll(t *testing.T) {
 	}
 
 	//check
-	check := map[string]Parser{}
+	check := map[string]parse.Parser{}
 	stringParser.SetValue("INFO")
 	check["loglevel"] = &stringParser
-	durationParser.SetValue(Duration(time.Second))
+	durationParser.SetValue(time.Duration(time.Second))
 	check["timeout"] = &durationParser
 	boolParser.SetValue(true)
 	check["db"] = &boolParser
 	check["db.watch"] = &boolParser
-	checkDcIP := stringValue("192.168.0.1")
+	checkDcIP := parse.StringValue("192.168.0.1")
 	check["db.ip"] = &checkDcIP
 	intParser.SetValue(-1)
 	check["db.load"] = &intParser
@@ -692,24 +693,24 @@ func TestParseArgsErrorNoParser(t *testing.T) {
 		t.Errorf("Error %s", err.Error())
 	}
 	//init parsers
-	parsers := map[reflect.Type]Parser{}
-	var boolParser boolValue
+	parsers := map[reflect.Type]parse.Parser{}
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
 	args := []string{"-lCONTINUE"}
@@ -744,7 +745,7 @@ func TestGetDefaultValueInitConfigAllDefault(t *testing.T) {
 	checkDob, _ := time.Parse(time.RFC3339, "1993-09-12T07:32:00Z")
 	checkValue := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf("DEBUG"),
-		"timeout":            reflect.ValueOf(Duration(time.Second)),
+		"timeout":            reflect.ValueOf(time.Duration(time.Second)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{ServerInfo: ServerInfo{Watch: true, IP: "192.168.1.2", Load: 32, Load64: 64}, ConnectionMax: 3200000000, ConnectionMax64: 6400000000000000000}),
 		"db.watch":           reflect.ValueOf(true),
 		"db.ip":              reflect.ValueOf("192.168.1.2"),
@@ -784,7 +785,7 @@ func TestGetDefaultValueNoConfigNoDefault(t *testing.T) {
 	}
 	checkValue := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf(""),
-		"timeout":            reflect.ValueOf(Duration(0)),
+		"timeout":            reflect.ValueOf(time.Duration(0)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{}),
 		"db.watch":           reflect.ValueOf(false),
 		"db.ip":              reflect.ValueOf(""),
@@ -814,7 +815,7 @@ func TestGetDefaultValueInitConfigNoDefault(t *testing.T) {
 	config := &Configuration{
 		Name: "defaultName", //useless field not flaged
 		// LogLevel is not initialized, default value will be go default value : ""
-		Timeout: Duration(time.Millisecond),
+		Timeout: time.Duration(time.Millisecond),
 	}
 	defPointerConfig := &Configuration{
 		Db: nil, //If pointer field is nil, default value will be go default value
@@ -826,7 +827,7 @@ func TestGetDefaultValueInitConfigNoDefault(t *testing.T) {
 	}
 	checkValue := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf(""),
-		"timeout":            reflect.ValueOf(Duration(time.Millisecond)),
+		"timeout":            reflect.ValueOf(time.Duration(time.Millisecond)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{}),
 		"db.watch":           reflect.ValueOf(false),
 		"db.ip":              reflect.ValueOf(""),
@@ -864,7 +865,7 @@ func TestGetDefaultNoConfigAllDefault(t *testing.T) {
 	checkDob, _ := time.Parse(time.RFC3339, "1979-05-27T07:32:00Z")
 	checkValue := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf(""),
-		"timeout":            reflect.ValueOf(Duration(time.Duration(0))),
+		"timeout":            reflect.ValueOf(time.Duration(0)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{ServerInfo: ServerInfo{Watch: true, IP: "192.168.1.2", Load: 32, Load64: 64}, ConnectionMax: 3200000000, ConnectionMax64: 6400000000000000000}),
 		"db.watch":           reflect.ValueOf(true),
 		"db.ip":              reflect.ValueOf("192.168.1.2"),
@@ -892,39 +893,39 @@ func TestFillStructRecursiveNoConfigNoDefaultTrivialValmap(t *testing.T) {
 	config := &Configuration{}
 
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
 	//init valmap
-	valmap := map[string]Parser{}
+	valmap := map[string]parse.Parser{}
 	stringParser.SetValue("INFO")
 	valmap["loglevel"] = &stringParser
-	durationParser.SetValue(Duration(time.Second))
+	durationParser.SetValue(time.Duration(time.Second))
 	valmap["timeout"] = &durationParser
 
 	//init defaultValmap NoConfigNoDefault
 	defaultValmap := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf(""),
-		"timeout":            reflect.ValueOf(Duration(time.Duration(0))),
+		"timeout":            reflect.ValueOf(parse.Duration(time.Duration(0))),
 		"db":                 reflect.ValueOf(&DatabaseInfo{}),
 		"db.watch":           reflect.ValueOf(false),
 		"db.ip":              reflect.ValueOf(""),
@@ -948,7 +949,7 @@ func TestFillStructRecursiveNoConfigNoDefaultTrivialValmap(t *testing.T) {
 	// fmt.Printf("Got : %+v\n", config)
 	check := &Configuration{}
 	check.LogLevel = "INFO"
-	check.Timeout = Duration(time.Second)
+	check.Timeout = time.Duration(time.Second)
 	if !reflect.DeepEqual(config, check) {
 		t.Fatalf("Error :\nexpected \t%+v \ngot \t\t%+v\n", check, config)
 	}
@@ -959,38 +960,38 @@ func TestFillStructRecursiveNoConfigNoDefaultAllValmap(t *testing.T) {
 	config := &Configuration{}
 
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
 	//init valmap
-	valmap := map[string]Parser{}
+	valmap := map[string]parse.Parser{}
 	stringParser.SetValue("INFO")
 	valmap["loglevel"] = &stringParser
-	durationParser.SetValue(Duration(time.Second))
+	durationParser.SetValue(time.Duration(time.Second))
 	valmap["timeout"] = &durationParser
 	boolParser.SetValue(true)
 	valmap["db"] = &boolParser
 	valmap["db.watch"] = &boolParser
-	valmapDcIP := stringValue("192.168.0.1")
+	valmapDcIP := parse.StringValue("192.168.0.1")
 	valmap["db.ip"] = &valmapDcIP
 	intParser.SetValue(-1)
 	valmap["db.load"] = &intParser
@@ -1039,7 +1040,7 @@ func TestFillStructRecursiveNoConfigNoDefaultAllValmap(t *testing.T) {
 	checkDob, _ := time.Parse(time.RFC3339, "2016-04-20T17:39:00Z")
 	check := &Configuration{
 		LogLevel: "INFO",
-		Timeout:  Duration(time.Second),
+		Timeout:  time.Duration(time.Second),
 		Db: &DatabaseInfo{
 			ServerInfo: ServerInfo{
 				Watch:  true,
@@ -1068,30 +1069,30 @@ func TestFillStructRecursiveNoConfigAllDefaultNoValmap(t *testing.T) {
 	config := &Configuration{}
 
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
 	//init valmap
-	valmap := map[string]Parser{}
+	valmap := map[string]parse.Parser{}
 
 	//init defaultValmap NoConfigAllDefault
 	defaultStr := "DefaultOwnerNamePointer"
@@ -1130,30 +1131,30 @@ func TestFillStructRecursiveInitConfigAllDefaultNoValmap(t *testing.T) {
 	config := newConfiguration()
 
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
 	//init valmap
-	valmap := map[string]Parser{}
+	valmap := map[string]parse.Parser{}
 
 	//init defaultValmap InitConfigAllDefault from TestGetDefaultValueAll
 	checkDefaultStr := "DefaultOwnerNamePointer"
@@ -1161,7 +1162,7 @@ func TestFillStructRecursiveInitConfigAllDefaultNoValmap(t *testing.T) {
 	checkDob, _ := time.Parse(time.RFC3339, "1993-09-12T07:32:00Z")
 	defaultValmap := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf("DEBUG"),
-		"timeout":            reflect.ValueOf(Duration(time.Second)),
+		"timeout":            reflect.ValueOf(parse.Duration(time.Second)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{ServerInfo: ServerInfo{Watch: true, IP: "192.168.1.2", Load: 32, Load64: 64}, ConnectionMax: 3200000000, ConnectionMax64: 6400000000000000000}),
 		"db.watch":           reflect.ValueOf(true),
 		"db.ip":              reflect.ValueOf("192.168.1.2"),
@@ -1198,30 +1199,30 @@ func TestFillStructRecursiveInitConfigAllDefaultPointerValmap(t *testing.T) {
 	config := &Configuration{}
 
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
 	//init valmap
-	valmap := map[string]Parser{}
+	valmap := map[string]parse.Parser{}
 	boolParser.SetValue(true)
 	valmap["db"] = &boolParser
 	valmap["owner"] = &boolParser
@@ -1232,7 +1233,7 @@ func TestFillStructRecursiveInitConfigAllDefaultPointerValmap(t *testing.T) {
 	checkDob, _ := time.Parse(time.RFC3339, "1993-09-12T07:32:00Z")
 	defaultValmap := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf("DEBUG"),
-		"timeout":            reflect.ValueOf(Duration(time.Second)),
+		"timeout":            reflect.ValueOf(parse.Duration(time.Second)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{ServerInfo: ServerInfo{Watch: true, IP: "192.168.1.2", Load: 32, Load64: 64}, ConnectionMax: 3200000000, ConnectionMax64: 6400000000000000000}),
 		"db.watch":           reflect.ValueOf(true),
 		"db.ip":              reflect.ValueOf("192.168.1.2"),
@@ -1285,30 +1286,30 @@ func TestFillStructRecursiveInitConfigAllDefaultPointerUnderPointerValmap(t *tes
 	config := newConfiguration()
 
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
 	//init valmap
-	valmap := map[string]Parser{}
+	valmap := map[string]parse.Parser{}
 	boolParser.SetValue(true)
 	valmap["owner.name"] = &boolParser
 	// valmap["owner.name"] = &boolParser
@@ -1319,7 +1320,7 @@ func TestFillStructRecursiveInitConfigAllDefaultPointerUnderPointerValmap(t *tes
 	checkDob, _ := time.Parse(time.RFC3339, "1993-09-12T07:32:00Z")
 	defaultValmap := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf("DEBUG"),
-		"timeout":            reflect.ValueOf(Duration(time.Second)),
+		"timeout":            reflect.ValueOf(parse.Duration(time.Second)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{ServerInfo: ServerInfo{Watch: true, IP: "192.168.1.2", Load: 32, Load64: 64}, ConnectionMax: 3200000000, ConnectionMax64: 6400000000000000000}),
 		"db.watch":           reflect.ValueOf(true),
 		"db.ip":              reflect.ValueOf("192.168.1.2"),
@@ -1343,7 +1344,7 @@ func TestFillStructRecursiveInitConfigAllDefaultPointerUnderPointerValmap(t *tes
 	check := &Configuration{
 		Name:     "initName",
 		LogLevel: "DEBUG",
-		Timeout:  Duration(time.Second),
+		Timeout:  time.Duration(time.Second),
 		Owner: &OwnerInfo{
 			Name:        &checkDefaultStr,
 			DateOfBirth: checkDob,
@@ -1363,31 +1364,31 @@ func TestFillStructRecursiveNoConfigAllDefaultSomeValmap(t *testing.T) {
 	config := &Configuration{}
 
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 
 	//init valmap
-	valmap := map[string]Parser{}
-	durationParser.SetValue(5 * Duration(time.Second))
+	valmap := map[string]parse.Parser{}
+	durationParser.SetValue(5 * time.Duration(time.Second))
 	valmap["timeout"] = &durationParser
 	boolParser.SetValue(true)
 	valmap["db"] = &boolParser
@@ -1423,7 +1424,7 @@ func TestFillStructRecursiveNoConfigAllDefaultSomeValmap(t *testing.T) {
 	//CHECK
 	// fmt.Printf("Got : %+v\n", config)
 	check := &Configuration{}
-	check.Timeout = 5 * Duration(time.Second)
+	check.Timeout = 5 * time.Duration(time.Second)
 	check.Db = newDefaultPointersConfiguration().Db
 	check.Owner = newDefaultPointersConfiguration().Owner
 	check.Owner.DateOfBirth, _ = time.Parse(time.RFC3339, "2016-04-20T17:39:00Z")
@@ -1442,20 +1443,19 @@ func TestFillStructRecursiveWithRepeatedPtrStruct(t *testing.T) {
 	config := &ConfigurationWithRepeatedStruct{}
 
 	//init parsers
-	parsers := map[reflect.Type]Parser{
-	}
-	var stringParser stringValue
+	parsers := map[reflect.Type]parse.Parser{}
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
 
 	//init valmap
-	valmap := map[string]Parser{}
+	valmap := map[string]parse.Parser{}
 	stringParser.SetValue("test")
 	valmap["container.repeated.val"] = &stringParser
 
 	//init defaultValmap NoConfigAllDefault
 	defaultValmap := map[string]reflect.Value{
-		"repeated": reflect.ValueOf(&RepeatedStruct{Val:"Default"}),
-		"container": reflect.ValueOf(&RepeatedStructContainer{&RepeatedStruct{Val:"DefaultInContainer"}}),
+		"repeated":  reflect.ValueOf(&RepeatedStruct{Val: "Default"}),
+		"container": reflect.ValueOf(&RepeatedStructContainer{&RepeatedStruct{Val: "DefaultInContainer"}}),
 	}
 	//test
 	if err := fillStructRecursive(reflect.ValueOf(config), defaultValmap, valmap, ""); err != nil {
@@ -1485,7 +1485,7 @@ func TestLoadWithParsersInitConfigNoDefaultNoFlag(t *testing.T) {
 	//init default pointers
 	defaultPointers := &Configuration{}
 	//init custom parsers
-	customParsers := map[reflect.Type]Parser{
+	customParsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
 	//init args
@@ -1515,7 +1515,7 @@ func TestLoadWithParsersInitConfigAllDefaultNoFlag(t *testing.T) {
 	//init default pointers
 	defaultPointers := newDefaultPointersConfiguration()
 	//init custom parsers
-	customParsers := map[reflect.Type]Parser{
+	customParsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
 	//init args
@@ -1545,7 +1545,7 @@ func TestLoadWithParsersInitConfigNoDefaultAllFlag(t *testing.T) {
 	//init default pointers
 	defaultPointers := &Configuration{}
 	//init custom parsers
-	customParsers := map[reflect.Type]Parser{
+	customParsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
 	//init args
@@ -1577,7 +1577,7 @@ func TestLoadWithParsersInitConfigNoDefaultAllFlag(t *testing.T) {
 	check := &Configuration{
 		Name:     "initName",
 		LogLevel: "INFO",
-		Timeout:  Duration(time.Second),
+		Timeout:  time.Duration(time.Second),
 		Db: &DatabaseInfo{
 			ServerInfo: ServerInfo{
 				Watch:  true,
@@ -1612,7 +1612,7 @@ func TestLoadWithParsersInitConfigAllDefaultSomeFlag(t *testing.T) {
 	//init default pointers
 	defaultPointers := newDefaultPointersConfiguration()
 	//init custom parsers
-	customParsers := map[reflect.Type]Parser{
+	customParsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
 	//init args
@@ -1653,7 +1653,7 @@ func TestLoadWithParsersNoConfigAllDefaultSomeFlag(t *testing.T) {
 	//init default pointers
 	defaultPointers := newDefaultPointersConfiguration()
 	//init custom parsers
-	customParsers := map[reflect.Type]Parser{
+	customParsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
 	//init args
@@ -1740,26 +1740,26 @@ func TestParseArgsInvalidArgument(t *testing.T) {
 		t.Errorf("Error %s", err.Error())
 	}
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
 	args := []string{
@@ -1782,26 +1782,26 @@ func TestParseArgsErrorUnknownFlag(t *testing.T) {
 		t.Errorf("Error %s", err.Error())
 	}
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
 	args := []string{
@@ -1822,26 +1822,26 @@ func TestPrintErrorInvalidArgument(t *testing.T) {
 		t.Errorf("Error %s", err.Error())
 	}
 	//init parsers
-	parsers := map[reflect.Type]Parser{
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf([]ServerInfo{}): &sliceServerValue{},
 	}
-	var boolParser boolValue
+	var boolParser parse.BoolValue
 	parsers[reflect.TypeOf(true)] = &boolParser
-	var intParser intValue
+	var intParser parse.IntValue
 	parsers[reflect.TypeOf(1)] = &intParser
-	var int64Parser int64Value
+	var int64Parser parse.Int64Value
 	parsers[reflect.TypeOf(int64(1))] = &int64Parser
-	var uintParser uintValue
+	var uintParser parse.UintValue
 	parsers[reflect.TypeOf(uint(1))] = &uintParser
-	var uint64Parser uint64Value
+	var uint64Parser parse.Uint64Value
 	parsers[reflect.TypeOf(uint64(1))] = &uint64Parser
-	var stringParser stringValue
+	var stringParser parse.StringValue
 	parsers[reflect.TypeOf("")] = &stringParser
-	var float64Parser float64Value
+	var float64Parser parse.Float64Value
 	parsers[reflect.TypeOf(float64(1.5))] = &float64Parser
-	var durationParser Duration
-	parsers[reflect.TypeOf(Duration(time.Second))] = &durationParser
-	var timeParser timeValue
+	var durationParser parse.Duration
+	parsers[reflect.TypeOf(time.Duration(time.Second))] = &durationParser
+	var timeParser parse.TimeValue
 	parsers[reflect.TypeOf(time.Now())] = &timeParser
 	//init args
 	args := []string{
@@ -1853,7 +1853,7 @@ func TestPrintErrorInvalidArgument(t *testing.T) {
 	checkDob, _ := time.Parse(time.RFC3339, "1993-09-12T07:32:00Z")
 	defaultValmap := map[string]reflect.Value{
 		"loglevel":           reflect.ValueOf("DEBUG"),
-		"timeout":            reflect.ValueOf(Duration(time.Second)),
+		"timeout":            reflect.ValueOf(time.Duration(time.Second)),
 		"db":                 reflect.ValueOf(&DatabaseInfo{ServerInfo: ServerInfo{Watch: true, IP: "192.168.1.2", Load: 32, Load64: 64}, ConnectionMax: 3200000000, ConnectionMax64: 6400000000000000000}),
 		"db.watch":           reflect.ValueOf(true),
 		"db.ip":              reflect.ValueOf("192.168.1.2"),
@@ -2525,7 +2525,7 @@ func TestSetPointersNilFullConfig(t *testing.T) {
 	config := &Configuration{
 		Name:     "Toto",
 		LogLevel: "Tata",
-		Timeout:  Duration(time.Nanosecond),
+		Timeout:  time.Duration(time.Nanosecond),
 		Db: &DatabaseInfo{
 			ServerInfo: ServerInfo{
 				Watch:  true,
@@ -2550,7 +2550,7 @@ func TestSetPointersNilFullConfig(t *testing.T) {
 	check := &Configuration{
 		Name:     "Toto",
 		LogLevel: "Tata",
-		Timeout:  Duration(time.Nanosecond),
+		Timeout:  time.Duration(time.Nanosecond),
 	}
 	if !reflect.DeepEqual(nilPointersConfig.Interface(), check) {
 		t.Errorf("\nexpected \t%+v \ngot \t\t%+v\n", check, nilPointersConfig.Interface())
@@ -2558,7 +2558,7 @@ func TestSetPointersNilFullConfig(t *testing.T) {
 	checkInit := &Configuration{
 		Name:     "Toto",
 		LogLevel: "Tata",
-		Timeout:  Duration(time.Nanosecond),
+		Timeout:  time.Duration(time.Nanosecond),
 		Db: &DatabaseInfo{
 			ServerInfo: ServerInfo{
 				Watch:  true,
@@ -2744,8 +2744,8 @@ func TestTypoPrintHelp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error, %s", err.Error())
 	}
-	var stringParser stringValue
-	parsers := map[reflect.Type]Parser{
+	var stringParser parse.StringValue
+	parsers := map[reflect.Type]parse.Parser{
 		reflect.TypeOf(""): &stringParser,
 	}
 	defaultValmap := map[string]reflect.Value{}

--- a/flaeg_test.go
+++ b/flaeg_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	parse "github.com/containous/flaeg/parse"
+	"github.com/containous/flaeg/parse"
 )
 
 //ConfigurationWithRepeatedStruct is struct which contains repeated struct

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -1,4 +1,4 @@
-package flaeg
+package parse
 
 import (
 	"flag"
@@ -17,130 +17,130 @@ type Parser interface {
 }
 
 // -- bool Value
-type boolValue bool
+type BoolValue bool
 
-func (b *boolValue) Set(s string) error {
+func (b *BoolValue) Set(s string) error {
 	v, err := strconv.ParseBool(s)
-	*b = boolValue(v)
+	*b = BoolValue(v)
 	return err
 }
 
-func (b *boolValue) Get() interface{} { return bool(*b) }
+func (b *BoolValue) Get() interface{} { return bool(*b) }
 
-func (b *boolValue) String() string { return fmt.Sprintf("%v", *b) }
+func (b *BoolValue) String() string { return fmt.Sprintf("%v", *b) }
 
-func (b *boolValue) IsBoolFlag() bool { return true }
+func (b *BoolValue) IsBoolFlag() bool { return true }
 
-func (b *boolValue) SetValue(val interface{}) {
-	*b = boolValue(val.(bool))
+func (b *BoolValue) SetValue(val interface{}) {
+	*b = BoolValue(val.(bool))
 }
 
 // optional interface to indicate boolean flags that can be
 // supplied without "=value" text
-type boolFlag interface {
+type BoolFlag interface {
 	flag.Value
 	IsBoolFlag() bool
 }
 
 // -- int Value
-type intValue int
+type IntValue int
 
-func (i *intValue) Set(s string) error {
+func (i *IntValue) Set(s string) error {
 	v, err := strconv.ParseInt(s, 0, 64)
-	*i = intValue(v)
+	*i = IntValue(v)
 	return err
 }
 
-func (i *intValue) Get() interface{} { return int(*i) }
+func (i *IntValue) Get() interface{} { return int(*i) }
 
-func (i *intValue) String() string { return fmt.Sprintf("%v", *i) }
+func (i *IntValue) String() string { return fmt.Sprintf("%v", *i) }
 
-func (i *intValue) SetValue(val interface{}) {
-	*i = intValue(val.(int))
+func (i *IntValue) SetValue(val interface{}) {
+	*i = IntValue(val.(int))
 }
 
 // -- int64 Value
-type int64Value int64
+type Int64Value int64
 
-func (i *int64Value) Set(s string) error {
+func (i *Int64Value) Set(s string) error {
 	v, err := strconv.ParseInt(s, 0, 64)
-	*i = int64Value(v)
+	*i = Int64Value(v)
 	return err
 }
 
-func (i *int64Value) Get() interface{} { return int64(*i) }
+func (i *Int64Value) Get() interface{} { return int64(*i) }
 
-func (i *int64Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *Int64Value) String() string { return fmt.Sprintf("%v", *i) }
 
-func (i *int64Value) SetValue(val interface{}) {
-	*i = int64Value(val.(int64))
+func (i *Int64Value) SetValue(val interface{}) {
+	*i = Int64Value(val.(int64))
 }
 
 // -- uint Value
-type uintValue uint
+type UintValue uint
 
-func (i *uintValue) Set(s string) error {
+func (i *UintValue) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 64)
-	*i = uintValue(v)
+	*i = UintValue(v)
 	return err
 }
 
-func (i *uintValue) Get() interface{} { return uint(*i) }
+func (i *UintValue) Get() interface{} { return uint(*i) }
 
-func (i *uintValue) String() string { return fmt.Sprintf("%v", *i) }
+func (i *UintValue) String() string { return fmt.Sprintf("%v", *i) }
 
-func (i *uintValue) SetValue(val interface{}) {
-	*i = uintValue(val.(uint))
+func (i *UintValue) SetValue(val interface{}) {
+	*i = UintValue(val.(uint))
 }
 
 // -- uint64 Value
-type uint64Value uint64
+type Uint64Value uint64
 
-func (i *uint64Value) Set(s string) error {
+func (i *Uint64Value) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 64)
-	*i = uint64Value(v)
+	*i = Uint64Value(v)
 	return err
 }
 
-func (i *uint64Value) Get() interface{} { return uint64(*i) }
+func (i *Uint64Value) Get() interface{} { return uint64(*i) }
 
-func (i *uint64Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *Uint64Value) String() string { return fmt.Sprintf("%v", *i) }
 
-func (i *uint64Value) SetValue(val interface{}) {
-	*i = uint64Value(val.(uint64))
+func (i *Uint64Value) SetValue(val interface{}) {
+	*i = Uint64Value(val.(uint64))
 }
 
 // -- string Value
-type stringValue string
+type StringValue string
 
-func (s *stringValue) Set(val string) error {
-	*s = stringValue(val)
+func (s *StringValue) Set(val string) error {
+	*s = StringValue(val)
 	return nil
 }
 
-func (s *stringValue) Get() interface{} { return string(*s) }
+func (s *StringValue) Get() interface{} { return string(*s) }
 
-func (s *stringValue) String() string { return fmt.Sprintf("%s", *s) }
+func (s *StringValue) String() string { return fmt.Sprintf("%s", *s) }
 
-func (s *stringValue) SetValue(val interface{}) {
-	*s = stringValue(val.(string))
+func (s *StringValue) SetValue(val interface{}) {
+	*s = StringValue(val.(string))
 }
 
 // -- float64 Value
-type float64Value float64
+type Float64Value float64
 
-func (f *float64Value) Set(s string) error {
+func (f *Float64Value) Set(s string) error {
 	v, err := strconv.ParseFloat(s, 64)
-	*f = float64Value(v)
+	*f = Float64Value(v)
 	return err
 }
 
-func (f *float64Value) Get() interface{} { return float64(*f) }
+func (f *Float64Value) Get() interface{} { return float64(*f) }
 
-func (f *float64Value) String() string { return fmt.Sprintf("%v", *f) }
+func (f *Float64Value) String() string { return fmt.Sprintf("%v", *f) }
 
-func (f *float64Value) SetValue(val interface{}) {
-	*f = float64Value(val.(float64))
+func (f *Float64Value) SetValue(val interface{}) {
+	*f = Float64Value(val.(float64))
 }
 
 // Duration is a custom type suitable for parsing duration values.
@@ -168,7 +168,7 @@ func (d *Duration) String() string { return (*time.Duration)(d).String() }
 
 // SetValue sets the duration from the given Duration-asserted value.
 func (d *Duration) SetValue(val interface{}) {
-	*d = Duration(val.(Duration))
+	*d = Duration(val.(time.Duration))
 }
 
 // UnmarshalText deserializes the given text into a duration value.
@@ -178,20 +178,20 @@ func (d *Duration) UnmarshalText(text []byte) error {
 }
 
 // -- time.Time Value
-type timeValue time.Time
+type TimeValue time.Time
 
-func (t *timeValue) Set(s string) error {
+func (t *TimeValue) Set(s string) error {
 	v, err := time.Parse(time.RFC3339, s)
-	*t = timeValue(v)
+	*t = TimeValue(v)
 	return err
 }
 
-func (t *timeValue) Get() interface{} { return time.Time(*t) }
+func (t *TimeValue) Get() interface{} { return time.Time(*t) }
 
-func (t *timeValue) String() string { return (*time.Time)(t).String() }
+func (t *TimeValue) String() string { return (*time.Time)(t).String() }
 
-func (t *timeValue) SetValue(val interface{}) {
-	*t = timeValue(val.(time.Time))
+func (t *TimeValue) SetValue(val interface{}) {
+	*t = TimeValue(val.(time.Time))
 }
 
 //SliceStrings parse slice of strings

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -168,7 +168,7 @@ func (d *Duration) String() string { return (*time.Duration)(d).String() }
 
 // SetValue sets the duration from the given Duration-asserted value.
 func (d *Duration) SetValue(val interface{}) {
-	*d = Duration(val.(time.Duration))
+	*d = Duration(val.(Duration))
 }
 
 // UnmarshalText deserializes the given text into a duration value.

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -1,4 +1,4 @@
-package flaeg
+package parse
 
 import (
 	"reflect"

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestSliceStringsSet(t *testing.T) {
 	checkMap := map[string]SliceStrings{
-		"str":            SliceStrings{"str"},
-		"str1,str2":      SliceStrings{"str1", "str2"},
-		"str1;str2":      SliceStrings{"str1", "str2"},
-		"str1,str2;str3": SliceStrings{"str1", "str2", "str3"},
+		"str":            {"str"},
+		"str1,str2":      {"str1", "str2"},
+		"str1;str2":      {"str1", "str2"},
+		"str1,str2;str3": {"str1", "str2", "str3"},
 	}
 	for str, check := range checkMap {
 		var slice SliceStrings
@@ -38,14 +38,14 @@ func TestSliceStringsSetAdd(t *testing.T) {
 
 func TestSliceStringsGet(t *testing.T) {
 	slices := []SliceStrings{
-		SliceStrings{"str"},
-		SliceStrings{"str1", "str2"},
-		SliceStrings{"str1", "str2", "str3"},
+		{"str"},
+		{"str1", "str2"},
+		{"str1", "str2", "str3"},
 	}
 	check := [][]string{
-		[]string{"str"},
-		[]string{"str1", "str2"},
-		[]string{"str1", "str2", "str3"},
+		{"str"},
+		{"str1", "str2"},
+		{"str1", "str2", "str3"},
 	}
 	for i, slice := range slices {
 		if !reflect.DeepEqual(slice.Get(), check[i]) {
@@ -56,9 +56,9 @@ func TestSliceStringsGet(t *testing.T) {
 
 func TestSliceStringsString(t *testing.T) {
 	slices := []SliceStrings{
-		SliceStrings{"str"},
-		SliceStrings{"str1", "str2"},
-		SliceStrings{"str1", "str2", "str3"},
+		{"str"},
+		{"str1", "str2"},
+		{"str1", "str2", "str3"},
 	}
 	check := []string{
 		"[str]",
@@ -74,14 +74,14 @@ func TestSliceStringsString(t *testing.T) {
 
 func TestSliceStringsSetValue(t *testing.T) {
 	check := []SliceStrings{
-		SliceStrings{"str"},
-		SliceStrings{"str1", "str2"},
-		SliceStrings{"str1", "str2", "str3"},
+		{"str"},
+		{"str1", "str2"},
+		{"str1", "str2", "str3"},
 	}
 	slices := [][]string{
-		[]string{"str"},
-		[]string{"str1", "str2"},
-		[]string{"str1", "str2", "str3"},
+		{"str"},
+		{"str1", "str2"},
+		{"str1", "str2", "str3"},
 	}
 	for i, s := range slices {
 		var slice SliceStrings


### PR DESCRIPTION
Fixes #40 (minus potential refactoring)

~Please review in particular the `Duration` it was a bit more tricky due to the naming ambiguity between `time.Duration` and `parse.Duration` should be alright though as all tests pass~