### PR TITLE
Fix Duration JSON Unmarshal

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -192,6 +192,11 @@ func (d *Duration) SetValue(val interface{}) {
 	*d = val.(Duration)
 }
 
+// MarshalText serialize the given duration value into a text.
+func (d *Duration) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
+}
+
 // UnmarshalText deserializes the given text into a duration value.
 // It is meant to support TOML decoding of durations.
 func (d *Duration) UnmarshalText(text []byte) error {

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -198,6 +198,16 @@ func (d *Duration) UnmarshalText(text []byte) error {
 	return d.Set(string(text))
 }
 
+// UnmarshalJSON deserializes the given text into a duration value.
+func (d *Duration) UnmarshalJSON(text []byte) error {
+	if v, err := strconv.Atoi(string(text)); err == nil {
+		*d = Duration(time.Duration(v))
+		return nil
+	}
+	d.Set(string(text))
+	return nil
+}
+
 // TimeValue time.Time Value
 type TimeValue time.Time
 

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -209,8 +209,10 @@ func (d *Duration) UnmarshalJSON(text []byte) error {
 		*d = Duration(time.Duration(v))
 		return nil
 	}
-	d.Set(string(text))
-	return nil
+
+	v, err := time.ParseDuration(string(text))
+	*d = Duration(v)
+	return err
 }
 
 // TimeValue time.Time Value

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -7,96 +7,170 @@ import (
 )
 
 func TestSliceStringsSet(t *testing.T) {
-	checkMap := map[string]SliceStrings{
-		"str":            {"str"},
-		"str1,str2":      {"str1", "str2"},
-		"str1;str2":      {"str1", "str2"},
-		"str1,str2;str3": {"str1", "str2", "str3"},
+	testCases := []struct {
+		desc     string
+		value    string
+		expected SliceStrings
+	}{
+		{
+			desc:     "one value",
+			value:    "str",
+			expected: SliceStrings{"str"},
+		},
+		{
+			desc:     "two values comma",
+			value:    "str1,str2",
+			expected: SliceStrings{"str1", "str2"},
+		},
+		{
+			desc:     "two values semicolon",
+			value:    "str1;str2",
+			expected: SliceStrings{"str1", "str2"},
+		},
+		{
+			desc:     "three values semicolon",
+			value:    "str1,str2;str3",
+			expected: SliceStrings{"str1", "str2", "str3"},
+		},
 	}
 
-	for str, check := range checkMap {
-		var slice SliceStrings
-		if err := slice.Set(str); err != nil {
-			t.Fatalf("Error :%s", err)
-		}
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 
-		if !reflect.DeepEqual(slice, check) {
-			t.Errorf("Expected: %s\ngot: %s", check, slice)
-		}
+			var slice SliceStrings
+			if err := slice.Set(test.value); err != nil {
+				t.Fatalf("Error :%s", err)
+			}
+
+			if !reflect.DeepEqual(slice, test.expected) {
+				t.Errorf("Got: %v\nexpected: %s", slice, test.expected)
+			}
+		})
 	}
 }
 
 func TestSliceStringsSetAdd(t *testing.T) {
 	slice := SliceStrings{"str1"}
 
-	//test
+	// test
 	if err := slice.Set("str2,str3"); err != nil {
 		t.Fatalf("Error :%s", err)
 	}
 
-	//check
-	check := SliceStrings{"str1", "str2", "str3"}
-	if !reflect.DeepEqual(slice, check) {
-		t.Errorf("Expected: %s\ngot: %s", check, slice)
+	// check
+	expected := SliceStrings{"str1", "str2", "str3"}
+	if !reflect.DeepEqual(slice, expected) {
+		t.Errorf("Expected: %s\ngot: %s", expected, slice)
 	}
 }
 
 func TestSliceStringsGet(t *testing.T) {
-	slices := []SliceStrings{
-		{"str"},
-		{"str1", "str2"},
-		{"str1", "str2", "str3"},
-	}
-	check := [][]string{
-		{"str"},
-		{"str1", "str2"},
-		{"str1", "str2", "str3"},
+	testCases := []struct {
+		desc     string
+		values   SliceStrings
+		expected []string
+	}{
+		{
+			desc:     "one value",
+			values:   SliceStrings{"str1"},
+			expected: []string{"str1"},
+		},
+		{
+			desc:     "two values",
+			values:   SliceStrings{"str1", "str2"},
+			expected: []string{"str1", "str2"},
+		},
+		{
+			desc:     "three values",
+			values:   SliceStrings{"str1", "str2", "str3"},
+			expected: []string{"str1", "str2", "str3"},
+		},
 	}
 
-	for i, slice := range slices {
-		if !reflect.DeepEqual(slice.Get(), check[i]) {
-			t.Errorf("Expected: %s\ngot: %s", check[i], slice)
-		}
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if !reflect.DeepEqual(test.values.Get(), test.expected) {
+				t.Errorf("Got: %v\nexpected: %s", test.values.Get(), test.expected)
+			}
+		})
 	}
 }
 
 func TestSliceStringsString(t *testing.T) {
-	slices := []SliceStrings{
-		{"str"},
-		{"str1", "str2"},
-		{"str1", "str2", "str3"},
-	}
-	check := []string{
-		"[str]",
-		"[str1 str2]",
-		"[str1 str2 str3]",
+	testCases := []struct {
+		desc     string
+		values   SliceStrings
+		expected string
+	}{
+		{
+			desc:     "one value",
+			values:   SliceStrings{"str"},
+			expected: "[str]",
+		},
+		{
+			desc:     "two values",
+			values:   SliceStrings{"str1", "str2"},
+			expected: "[str1 str2]",
+		},
+		{
+			desc:     "three values",
+			values:   SliceStrings{"str1", "str2", "str3"},
+			expected: "[str1 str2 str3]",
+		},
 	}
 
-	for i, slice := range slices {
-		if !reflect.DeepEqual(slice.String(), check[i]) {
-			t.Errorf("Expected:%s\ngot:%s", check[i], slice)
-		}
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if !reflect.DeepEqual(test.values.String(), test.expected) {
+				t.Errorf("Got: %s\nexpected: %s", test.values.String(), test.expected)
+			}
+		})
 	}
 }
 
 func TestSliceStringsSetValue(t *testing.T) {
-	check := []SliceStrings{
-		{"str"},
-		{"str1", "str2"},
-		{"str1", "str2", "str3"},
-	}
-	slices := [][]string{
-		{"str"},
-		{"str1", "str2"},
-		{"str1", "str2", "str3"},
+	testCases := []struct {
+		desc     string
+		values   []string
+		expected SliceStrings
+	}{
+		{
+			desc:     "one value",
+			values:   []string{"str"},
+			expected: SliceStrings{"str"},
+		},
+		{
+			desc:     "two values",
+			values:   []string{"str1", "str2"},
+			expected: SliceStrings{"str1", "str2"},
+		},
+		{
+			desc:     "three values",
+			values:   []string{"str1", "str2", "str3"},
+			expected: SliceStrings{"str1", "str2", "str3"},
+		},
 	}
 
-	for i, s := range slices {
-		var slice SliceStrings
-		slice.SetValue(s)
-		if !reflect.DeepEqual(slice, check[i]) {
-			t.Errorf("Expected: %s\ngot: %s", check[i], slice)
-		}
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var slice SliceStrings
+			slice.SetValue(test.values)
+
+			if !reflect.DeepEqual(slice, test.expected) {
+				t.Errorf("Got: %s\nexpected: %s", slice, test.expected)
+			}
+		})
 	}
 }
 
@@ -126,7 +200,7 @@ func TestSetDuration(t *testing.T) {
 
 			var dur Duration
 			if err := dur.Set(test.in); err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 
 			if time.Duration(dur) != test.out {
@@ -137,31 +211,80 @@ func TestSetDuration(t *testing.T) {
 }
 
 func TestUnmarshalTextDuration(t *testing.T) {
-	var dur Duration
-	if err := dur.UnmarshalText([]byte("42")); err != nil {
-		t.Fatalf("got error %s", err)
+	testCases := []struct {
+		desc     string
+		value    []byte
+		expected time.Duration
+	}{
+		{
+			desc:     "no unit",
+			value:    []byte("42"),
+			expected: 42 * time.Second,
+		},
+		{
+			desc:     "second",
+			value:    []byte("42s"),
+			expected: 42 * time.Second,
+		},
+		{
+			desc:     "minute second",
+			value:    []byte("4m2s"),
+			expected: 242 * time.Second,
+		},
 	}
 
-	if time.Duration(dur) != 42*time.Second {
-		t.Errorf("got %#v, want %#v", time.Duration(dur), 42*time.Second)
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var dur Duration
+			if err := dur.UnmarshalText(test.value); err != nil {
+				t.Error(err)
+			}
+
+			if time.Duration(dur) != test.expected {
+				t.Errorf("got %#v, want %#v", time.Duration(dur), test.expected)
+			}
+		})
 	}
 }
 
 func TestMarshalTextDuration(t *testing.T) {
-	var dur Duration
-	dur.Set("42")
-	duration, _ := dur.MarshalText()
-	if string(duration) != "42s" {
-		t.Errorf("got %#v, want %#v", dur, "42s")
+	testCases := []struct {
+		desc     string
+		value    string
+		expected string
+	}{
+		{
+			desc:     "second",
+			value:    "42",
+			expected: "42s",
+		},
+		{
+			desc:     "hour minute second",
+			value:    "3670",
+			expected: "1h1m10s",
+		},
 	}
-}
 
-func TestMarshalTextDurationWithHourAndMinutes(t *testing.T) {
-	var dur Duration
-	dur.Set("3670")
-	duration, _ := dur.MarshalText()
-	if string(duration) != "1h1m10s" {
-		t.Errorf("got %#v, want %#v", dur, "1h1m10s")
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var dur Duration
+			err := dur.Set(test.value)
+			if err != nil {
+				t.Error(err)
+			}
+
+			result, _ := dur.MarshalText()
+
+			if string(result) != test.expected {
+				t.Errorf("got %v, want %s", dur, test.expected)
+			}
+		})
 	}
 }
 
@@ -190,7 +313,7 @@ func TestUnmarshalJsonDuration(t *testing.T) {
 
 			var dur Duration
 			if err := dur.UnmarshalJSON([]byte(test.value)); err != nil {
-				t.Fatalf("go error %s", err)
+				t.Error(err)
 			}
 
 			if time.Duration(dur) != test.expected {
@@ -200,7 +323,7 @@ func TestUnmarshalJsonDuration(t *testing.T) {
 	}
 }
 
-func TestUnmarshalJsonDuratioError(t *testing.T) {
+func TestUnmarshalJsonDurationError(t *testing.T) {
 	testCases := []struct {
 		desc  string
 		value string
@@ -222,7 +345,7 @@ func TestUnmarshalJsonDuratioError(t *testing.T) {
 
 			var dur Duration
 			if err := dur.UnmarshalJSON([]byte(test.value)); err == nil {
-				t.Fatal("want error got nil")
+				t.Errorf("want error got nil")
 			}
 		})
 	}

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -146,3 +146,14 @@ func TestUnmarshalTextDuration(t *testing.T) {
 		t.Errorf("got %#v, want %#v", time.Duration(dur), 42*time.Second)
 	}
 }
+
+func TestUnmarshalJsonDuration(t *testing.T) {
+	var dur Duration
+	if err := dur.UnmarshalJSON([]byte("1000000000")); err != nil {
+		t.Fatalf("go error %s", err)
+	}
+
+	if time.Duration(dur) != time.Second {
+		t.Errorf("got %#v, want %#v", time.Duration(dur), time.Second)
+	}
+}

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -147,6 +147,24 @@ func TestUnmarshalTextDuration(t *testing.T) {
 	}
 }
 
+func TestMarshalTextDuration(t *testing.T) {
+	var dur Duration
+	dur.Set("42")
+	duration, _ := dur.MarshalText()
+	if string(duration) != "42s" {
+		t.Errorf("got %#v, want %#v", dur, "42s")
+	}
+}
+
+func TestMarshalTextDurationWithHourAndMinutes(t *testing.T) {
+	var dur Duration
+	dur.Set("3670")
+	duration, _ := dur.MarshalText()
+	if string(duration) != "1h1m10s" {
+		t.Errorf("got %#v, want %#v", dur, "1h1m10s")
+	}
+}
+
 func TestUnmarshalJsonDuration(t *testing.T) {
 	var dur Duration
 	if err := dur.UnmarshalJSON([]byte("1000000000")); err != nil {

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -166,12 +166,64 @@ func TestMarshalTextDurationWithHourAndMinutes(t *testing.T) {
 }
 
 func TestUnmarshalJsonDuration(t *testing.T) {
-	var dur Duration
-	if err := dur.UnmarshalJSON([]byte("1000000000")); err != nil {
-		t.Fatalf("go error %s", err)
+	testCases := []struct {
+		desc     string
+		value    string
+		expected time.Duration
+	}{
+		{
+			desc:     "1 second",
+			value:    "1000000000",
+			expected: time.Duration(1000000000),
+		},
+		{
+			desc:     "with units",
+			value:    "1m10s",
+			expected: time.Duration(70000000000),
+		},
 	}
 
-	if time.Duration(dur) != time.Second {
-		t.Errorf("got %#v, want %#v", time.Duration(dur), time.Second)
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var dur Duration
+			if err := dur.UnmarshalJSON([]byte(test.value)); err != nil {
+				t.Fatalf("go error %s", err)
+			}
+
+			if time.Duration(dur) != test.expected {
+				t.Errorf("got %#v, want %#v", time.Duration(dur), test.expected)
+			}
+		})
+	}
+}
+
+func TestUnmarshalJsonDuratioError(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		value string
+	}{
+		{
+			desc:  "empty",
+			value: "",
+		},
+		{
+			desc:  "invalid units",
+			value: "1k10s",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var dur Duration
+			if err := dur.UnmarshalJSON([]byte(test.value)); err == nil {
+				t.Fatal("want error got nil")
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fix JSON Unmarshal.

When Marshal, `flaeg.Duration` become an `int`, that's why it needs to be handle as `int` when Unmarshalled.