### PR TITLE
Marshalling/Unmarshalling flaeg.Duration correctly

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -216,7 +216,13 @@ func (d *Duration) UnmarshalJSON(text []byte) error {
 		return nil
 	}
 
-	v, err := time.ParseDuration(string(text))
+	//We use json unmarshal on value because we have the quoted version
+	var value string
+	err := json.Unmarshal(text, &value)
+	if err != nil {
+		return err
+	}
+	v, err := time.ParseDuration(value)
 	*d = Duration(v)
 	return err
 }

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -216,7 +216,7 @@ func (d *Duration) UnmarshalJSON(text []byte) error {
 		return nil
 	}
 
-	//We use json unmarshal on value because we have the quoted version
+	// We use json unmarshal on value because we have the quoted version
 	var value string
 	err := json.Unmarshal(text, &value)
 	if err != nil {

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -1,6 +1,7 @@
 package parse
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"reflect"
@@ -201,6 +202,11 @@ func (d *Duration) MarshalText() ([]byte, error) {
 // It is meant to support TOML decoding of durations.
 func (d *Duration) UnmarshalText(text []byte) error {
 	return d.Set(string(text))
+}
+
+// MarshalJSON serializes the given duration value.
+func (d *Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(*d))
 }
 
 // UnmarshalJSON deserializes the given text into a duration value.

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -303,7 +303,7 @@ func TestUnmarshalJsonDuration(t *testing.T) {
 		},
 		{
 			desc:     "with units",
-			value:    "1m10s",
+			value:    "\"1m10s\"",
 			expected: time.Duration(70000000000),
 		},
 	}
@@ -380,5 +380,18 @@ func TestJsonMarshal(t *testing.T) {
 	}
 	if !strings.Contains(string(bytes), "666000000000") {
 		t.Fatalf("Marshal fail: %s", bytes)
+	}
+}
+
+func TestJsonUnmarshal(t *testing.T) {
+	pointer := Object{
+	}
+
+	err := json.Unmarshal([]byte(`{"Timeout": "10s"}`), &pointer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pointer.Timeout != 10000000000 {
+		t.Fatalf("Wrong value: %d instead of 10000000000", pointer.Timeout)
 	}
 }

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+	"encoding/json"
+	"strings"
 )
 
 func TestSliceStringsSet(t *testing.T) {
@@ -348,5 +350,35 @@ func TestUnmarshalJsonDurationError(t *testing.T) {
 				t.Errorf("want error got nil")
 			}
 		})
+	}
+}
+
+type Object struct {
+	Timeout Duration
+}
+
+func TestJsonMarshal(t *testing.T) {
+	pointer := &Object{
+		Timeout: Duration(666 * time.Second),
+	}
+
+	bytes, err := json.Marshal(pointer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(bytes), "666000000000") {
+		t.Fatalf("Marshal fail: %s", bytes)
+	}
+
+	object := Object{
+		Timeout: Duration(666 * time.Second),
+	}
+
+	bytes, err = json.Marshal(object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(bytes), "666000000000") {
+		t.Fatalf("Marshal fail: %s", bytes)
 	}
 }


### PR DESCRIPTION
Marshalling of `flaeg.Duration` become an `int`.
Unmarshalling now handle the quoted version of strings.