### PR TITLE
use ParseInt instead of Atoi for parsing durations

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -172,7 +172,7 @@ type Duration time.Duration
 
 // Set sets the duration from the given string value.
 func (d *Duration) Set(s string) error {
-	if v, err := strconv.Atoi(s); err == nil {
+	if v, err := strconv.ParseInt(s, 10, 64); err == nil {
 		*d = Duration(time.Duration(v) * time.Second)
 		return nil
 	}
@@ -211,7 +211,7 @@ func (d *Duration) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON deserializes the given text into a duration value.
 func (d *Duration) UnmarshalJSON(text []byte) error {
-	if v, err := strconv.Atoi(string(text)); err == nil {
+	if v, err := strconv.ParseInt(string(text), 10, 64); err == nil {
 		*d = Duration(time.Duration(v))
 		return nil
 	}

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -302,6 +302,12 @@ func TestUnmarshalJsonDuration(t *testing.T) {
 			expected: time.Duration(1000000000),
 		},
 		{
+			desc:     "10 seconds",
+			value:    "10000000000",
+			expected: time.Duration(10000000000),
+		},
+		{
+
 			desc:     "with units",
 			value:    "\"1m10s\"",
 			expected: time.Duration(70000000000),


### PR DESCRIPTION
Flaeg is failing to deserialize durations with values >= to 2^31 on 32 bits architectures.

This is caused by the usage of `Atoi` to parse duration, which returns an `int` not an `int64`.

During a JSON unmarshal of a duration for values >= to 2^32, Atoi will return an error and flaeg will try to parse the value as a string, which is going to fail too, causing the unmarshaling to fail.

Using `ParseInt(s, 10, 64)` fixes the problem, as it works on int64.

It is even a little bit faster according to [this](https://gist.github.com/evalphobia/caee1602969a640a4530) bench.